### PR TITLE
Remove Steam API Interferance

### DIFF
--- a/cool-characters-only/SteamReplace.cpp
+++ b/cool-characters-only/SteamReplace.cpp
@@ -1,0 +1,86 @@
+/**************************************************************************************
+ *   SteamReplace.cpp  --  This file is part of Cool Characters Only.                 *
+ *                                                                                    *
+ *   Copyright (C) 2024 Queen Suzie                                                   *
+ *                                                                                    *
+ *   Cool Characters Only is free software: you can redistribute it and/or modify     *
+ *   it under the terms of the GNU General Public License as published                *
+ *   by the Free Software Foundation, either version 3 of the License,                *
+ *   or (at your option) any later version.                                           *
+ *                                                                                    *
+ *   Cool Characters Only is distributed in the hope that it will be useful,          *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty                      *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                          *
+ *   See the GNU General Public License for more details.                             *
+ *                                                                                    *
+ *   You should have received a copy of the GNU General Public License                *
+ *   along with this program.  If not, see http://www.gnu.org/licenses/.              *
+ *                                                                                    *
+ *************************************************************************************/
+
+#include "pch.h"
+#include "SteamReplace.h"
+
+FunctionHook<void> hLeaderboardDownload((intptr_t)0x4120C0);
+FunctionHook<bool> hCheckNoInternetConnection((intptr_t)0x411AE0);
+FunctionHook<void> hShowNoInternet((intptr_t)0x411B30);
+FunctionHook<void> hAchievementsMenu((intptr_t)0x40D300);
+
+void SteamReplace::init() {
+	SteamReplace::FindSteam();
+	hLeaderboardDownload.Hook(LeaderboardDownload);
+	SteamStats.Hook(SteamStatistics);
+	LeaderboardLoad.Hook(LoadLeaderboard);
+	LeaderboardsMenu.Hook(LeaderboardsMenuItem);
+	hCheckNoInternetConnection.Hook(CheckNoInternetConnection);
+	hShowNoInternet.Hook(ShowNoInternetDialog);
+	hAchievementsMenu.Hook(AchievementsMenu);
+}
+
+void SteamReplace::FindSteam() {
+	DWORD cbNeeded;
+	HMODULE hMods[1024];
+	HANDLE currentProcess = GetCurrentProcess();
+	TCHAR steamApi[] = { 's', 't', 'e', 'a', 'm', '_', 'a', 'p', 'i', NULL };
+
+	if (currentProcess && EnumProcessModules(currentProcess, hMods, sizeof(hMods), &cbNeeded)) {
+		unsigned short hModsSize = cbNeeded / sizeof(HMODULE);
+		for (unsigned short i = 0; i < hModsSize; i++) {
+			TCHAR szModName[MAX_PATH];
+			if (GetModuleFileNameEx(currentProcess, hMods[i], szModName, sizeof(szModName) / sizeof(TCHAR))) {
+				TString modName(szModName);
+				if (modName.find(steamApi) != std::string::npos) {
+					return SteamReplace::SteamInit(hMods[i]);
+				}
+			}
+		}
+	}
+}
+
+void SteamReplace::SteamInit(HMODULE steam_api) {
+	FARPROC runCallbacks = GetProcAddress(steam_api, "SteamAPI_RunCallbacks");
+	FunctionHook<void> hRunCallbacks((intptr_t)runCallbacks);
+	hRunCallbacks.Hook(RunCallbacks);
+}
+
+void SteamReplace::LeaderboardDownload() {
+	dword_1AF19FC = 0;
+}
+
+void SteamReplace::SteamStatistics(int a1, int a2) {}
+
+void SteamReplace::LoadLeaderboard(int a1) {}
+
+signed int SteamReplace::LeaderboardsMenuItem(int a1) {
+	return 1;
+}
+
+void SteamReplace::AchievementsMenu() {}
+
+bool SteamReplace::CheckNoInternetConnection() {
+	return true;
+}
+
+void SteamReplace::ShowNoInternetDialog() {}
+
+void SteamReplace::RunCallbacks() {}

--- a/cool-characters-only/SteamReplace.h
+++ b/cool-characters-only/SteamReplace.h
@@ -1,7 +1,7 @@
 /**************************************************************************************
- *   main.cpp  --  This file is part of Cool Characters Only.                         *
+ *   SteamReplace.h  --  This file is part of Cool Characters Only.                   *
  *                                                                                    *
- *   Copyright (C) 2023 - 2024 Queen Suzie                                            *
+ *   Copyright (C) 2024 Queen Suzie                                                   *
  *                                                                                    *
  *   Cool Characters Only is free software: you can redistribute it and/or modify     *
  *   it under the terms of the GNU General Public License as published                *
@@ -18,22 +18,37 @@
  *                                                                                    *
  *************************************************************************************/
 
-#include "pch.h"
+#pragma once
 
-extern "C" {
-	__declspec(dllexport) void __cdecl Init(const char* path, const HelperFunctions& helperFunctions) {
-		SteamReplace::init();
-		ReplaceCharacters::init();
-		ReplaceStages::init();
-		StartingPositions pos;
-		pos.init();
-	}
+#include <psapi.h>
+#include <string>
 
-	__declspec(dllexport) void __cdecl OnExit() {
-		if (ReplaceStages::FallenHeroSequence) {
-			delete ReplaceStages::FallenHeroSequence;
-		}
-	}
+#ifndef UNICODE  
+typedef std::string TString;
+#else
+typedef std::wstring TString;
+#endif
 
-	__declspec(dllexport) ModInfo SA2ModInfo = { ModLoaderVer }; // This is needed for the Mod Loader to recognize the DLL.
-}
+DataPointer(DWORD, dword_1AF19FC, 0x1AF19FC);
+
+UsercallFuncVoid(SteamStats, (int a1, int a2), (a1, a2), (intptr_t)0x40E880, rEAX, rECX);
+UsercallFuncVoid(LeaderboardLoad, (int a1), (a1), (intptr_t)0x4108B0, rESI);
+UsercallFunc(signed int, LeaderboardsMenu, (int a1), (a1), (intptr_t)0x40F520, rEAX, rEBX);
+
+class SteamReplace
+{
+	public:
+		static void init();
+		static void LeaderboardDownload();
+		static void SteamStatistics(int, int);
+		static void LoadLeaderboard(int);
+		static signed int LeaderboardsMenuItem(int);
+		static void AchievementsMenu();
+		static bool CheckNoInternetConnection();
+		static void ShowNoInternetDialog();
+		static void RunCallbacks();
+
+	private:
+		static void FindSteam();
+		static void SteamInit(HMODULE);
+};

--- a/cool-characters-only/cool-characters-only.vcxproj
+++ b/cool-characters-only/cool-characters-only.vcxproj
@@ -152,10 +152,11 @@
   <ItemGroup>
     <ClInclude Include="framework.h" />
     <ClInclude Include="pch.h" />
-	<ClInclude Include="SequenceData.h" />
+    <ClInclude Include="SequenceData.h" />
     <ClInclude Include="ReplaceCharacters.h" />
     <ClInclude Include="ReplaceStages.h" />
     <ClInclude Include="StartingPositions.h" />
+    <ClInclude Include="SteamReplace.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp" />
@@ -169,6 +170,7 @@
     <ClCompile Include="ReplaceCharacters.cpp" />
     <ClCompile Include="ReplaceStages.cpp" />
     <ClCompile Include="StartingPositions.cpp" />
+    <ClCompile Include="SteamReplace.cpp" />
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="..\LICENSE">

--- a/cool-characters-only/cool-characters-only.vcxproj.filters
+++ b/cool-characters-only/cool-characters-only.vcxproj.filters
@@ -30,6 +30,12 @@
     <ClInclude Include="ReplaceStages.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="SequenceData.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="SteamReplace.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -48,6 +54,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="ReplaceStages.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="SteamReplace.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/cool-characters-only/dllmain.cpp
+++ b/cool-characters-only/dllmain.cpp
@@ -1,13 +1,13 @@
 // dllmain.cpp : Defines the entry point for the DLL application.
 #include "pch.h"
 
-BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved) {
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved) {
     switch (ul_reason_for_call) {
-    case DLL_PROCESS_ATTACH:
-    case DLL_THREAD_ATTACH:
-    case DLL_THREAD_DETACH:
-    case DLL_PROCESS_DETACH:
-        break;
+        case DLL_PROCESS_ATTACH:
+        case DLL_THREAD_ATTACH:
+        case DLL_THREAD_DETACH:
+        case DLL_PROCESS_DETACH:
+            break;
     }
 
     return TRUE;

--- a/cool-characters-only/pch.h
+++ b/cool-characters-only/pch.h
@@ -11,6 +11,8 @@
 #include "framework.h"
 #include "SA2ModLoader.h"
 #include "FunctionHook.h"
+#include "UsercallFunctionHandler.h"
+#include "SteamReplace.h"
 #include "SequenceData.h"
 #include "ReplaceCharacters.h"
 #include "ReplaceStages.h"


### PR DESCRIPTION
This PR should remove useless steam garbage from running in the game. For example, offline detection which provides absolutely zero value while disrupting gameplay needlessly.

Removes access to the fake leaderboard.

Removes access to pointless achievements that no one cares about.